### PR TITLE
Change error code in TestUploadPartNoSuchUpload()

### DIFF
--- a/s3tests/object_test.go
+++ b/s3tests/object_test.go
@@ -1513,7 +1513,7 @@ func (suite *S3Suite) TestUploadPartNoSuchUpload() {
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
 
-			assert.Equal(awsErr.Code(), "NoSuchKey")
+			assert.Equal(awsErr.Code(), "NoSuchUpload")
 			assert.Equal(awsErr.Message(), "")
 		}
 	}


### PR DESCRIPTION
NB: The places of the expected and actual values in the assert.Equal(.,.) function are interchanged throughout the test suite. This might mislead reading of error messages in failing tests.

Signed-off-by: Antoaneta Damyanova <adamyanova@gmail.com>